### PR TITLE
Cache access to ESBiomeSource

### DIFF
--- a/common/src/generated/resources/.cache/103d9f3f36b01595f1aa5172191e60eff02e6924
+++ b/common/src/generated/resources/.cache/103d9f3f36b01595f1aa5172191e60eff02e6924
@@ -1,4 +1,4 @@
-// 1.21.1	2025-01-01T22:56:08.6100435	Registries
+// 1.21.1	2025-01-04T00:15:30.248527739	Registries
 cdffa512172252fd00a692126bdb2d7e298e84a3 data/eternal_starlight/damage_type/bite.json
 7e028d9111c471543bdd218b17976d7a541b1f8b data/eternal_starlight/damage_type/crystalline_infection.json
 87798293859822fe3e1c8906d4575bc782e7977f data/eternal_starlight/damage_type/dagger_of_hunger.json
@@ -174,7 +174,7 @@ c64b583fa9c7f9aa1dbbbe67c3324a67a1a42ec7 data/eternal_starlight/worldgen/configu
 9194d27aacd267a2ca92abb592692a7e23d1f480 data/eternal_starlight/worldgen/configured_feature/voidstone_saltpeter_ore.json
 47822cf086e88bc38e89c92e416371978372cdb6 data/eternal_starlight/worldgen/configured_feature/waterside_vegetation.json
 fb7da92300b9f32412414a80e4b8194171642d8d data/eternal_starlight/worldgen/configured_feature/water_surface_plant.json
-a5d8979e3464ded8277525f6e570212cdb579236 data/eternal_starlight/worldgen/noise_settings/starlight.json
+f42ab1d3ed9a3f64f382ec4e6f73612effd01c98 data/eternal_starlight/worldgen/noise_settings/starlight.json
 d57ac474b708e97ffef972aea47c6ad7d0466c53 data/eternal_starlight/worldgen/placed_feature/abyssal_kelp.json
 0db106d6bc0831e0fdb95f9b551c2a479d18ba79 data/eternal_starlight/worldgen/placed_feature/abysslate_patch.json
 b80954db0b2372eb69ee23427b202fcc2b2a0ee9 data/eternal_starlight/worldgen/placed_feature/ashen_snow.json

--- a/common/src/generated/resources/data/eternal_starlight/worldgen/noise_settings/starlight.json
+++ b/common/src/generated/resources/data/eternal_starlight/worldgen/noise_settings/starlight.json
@@ -15,7 +15,7 @@
     "height": 384,
     "min_y": -64,
     "size_horizontal": 1,
-    "size_vertical": 2
+    "size_vertical": 4
   },
   "noise_router": {
     "barrier": 0.0,

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/data/ESDimensions.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/data/ESDimensions.java
@@ -85,7 +85,7 @@ public class ESDimensions {
 				-64,
 				384,
 				1,
-				2
+				4
 			),
 			ESBlocks.GRIMSTONE.get().defaultBlockState(),
 			Blocks.WATER.defaultBlockState(),

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/mixin/RandomStateMixin.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/mixin/RandomStateMixin.java
@@ -1,0 +1,35 @@
+package cn.leolezury.eternalstarlight.common.mixin;
+
+import cn.leolezury.eternalstarlight.common.world.gen.chunkgenerator.IRandomState;
+import net.minecraft.world.level.levelgen.RandomState;
+import net.minecraft.world.level.levelgen.SurfaceSystem;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(RandomState.class)
+public class RandomStateMixin implements IRandomState {
+
+	@Mutable
+	@Shadow
+	@Final
+	private SurfaceSystem surfaceSystem;
+
+	@Unique
+	@Override
+	public void setSurfaceSystem(SurfaceSystem surfaceSystem) {
+		this.surfaceSystem = surfaceSystem;
+	}
+
+	@Override
+	public RandomState clone() {
+		try {
+			return (RandomState) super.clone();
+		} catch (CloneNotSupportedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/mixin/SurfaceSystemMixin.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/mixin/SurfaceSystemMixin.java
@@ -1,5 +1,6 @@
 package cn.leolezury.eternalstarlight.common.mixin;
 
+import cn.leolezury.eternalstarlight.common.world.gen.biomesource.IESBiomeSource;
 import cn.leolezury.eternalstarlight.common.world.gen.chunkgenerator.ESChunkGenerator;
 import cn.leolezury.eternalstarlight.common.world.gen.chunkgenerator.StarlightSurfaceSystem;
 import net.minecraft.world.level.levelgen.SurfaceSystem;
@@ -11,13 +12,35 @@ public abstract class SurfaceSystemMixin implements StarlightSurfaceSystem {
 	@Unique
 	private ESChunkGenerator starlightGenerator;
 
+	@Unique
+	private IESBiomeSource cachedStarlightBiomeSource;
+
 	@Override
 	public void setStarlightChunkGenerator(ESChunkGenerator generator) {
 		starlightGenerator = generator;
 	}
 
 	@Override
+	public void setCachedStarlightBiomeSource(IESBiomeSource biomeSource) {
+		cachedStarlightBiomeSource = biomeSource;
+	}
+
+	@Override
 	public ESChunkGenerator getStarlightChunkGenerator() {
 		return starlightGenerator;
+	}
+
+	@Override
+	public IESBiomeSource getCachedStarlightBiomeSource() {
+		return cachedStarlightBiomeSource;
+	}
+
+	@Override
+	public SurfaceSystem clone() {
+		try {
+			return (SurfaceSystem) super.clone();
+		} catch (CloneNotSupportedException e) {
+			throw new RuntimeException(e);
+		}
 	}
 }

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/world/gen/biomesource/ESBiomeSource.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/world/gen/biomesource/ESBiomeSource.java
@@ -1,21 +1,25 @@
 package cn.leolezury.eternalstarlight.common.world.gen.biomesource;
 
 import cn.leolezury.eternalstarlight.common.world.gen.system.BiomeData;
+import cn.leolezury.eternalstarlight.common.world.gen.system.WorldArea;
 import cn.leolezury.eternalstarlight.common.world.gen.system.WorldGenProvider;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.unimi.dsi.fastutil.longs.Long2ReferenceArrayMap;
+import it.unimi.dsi.fastutil.longs.Long2ReferenceFunction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.RegistryCodecs;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeSource;
 import net.minecraft.world.level.biome.Climate;
 
 import java.util.stream.Stream;
 
-public class ESBiomeSource extends BiomeSource {
+public class ESBiomeSource extends BiomeSource implements IESBiomeSource {
 	public static final MapCodec<ESBiomeSource> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance.group(
 		WorldGenProvider.CODEC.fieldOf("worldgen_provider").forGetter(o -> o.provider),
 		RegistryCodecs.homogeneousList(Registries.BIOME).fieldOf("biomes").forGetter(o -> o.biomeHolderSet)
@@ -51,14 +55,17 @@ public class ESBiomeSource extends BiomeSource {
 		return biomeHolderSet.stream();
 	}
 
+	@Override
 	public BiomeData getBiomeData(int x, int z) {
 		return this.provider.getWorldArea(x, z).getBiomeData(x, z);
 	}
 
+	@Override
 	public int getBiome(int x, int z) {
 		return this.provider.getWorldArea(x, z).getBiome(x, z);
 	}
 
+	@Override
 	public int getHeight(int x, int z) {
 		return this.provider.getWorldArea(x, z).getHeight(x, z);
 	}
@@ -67,4 +74,62 @@ public class ESBiomeSource extends BiomeSource {
 	public Holder<Biome> getNoiseBiome(int x, int y, int z, Climate.Sampler sampler) {
 		return provider.getBiomeDataById(getBiome(x * 4, z * 4)).biome();
 	}
+
+	public Cached cache() {
+		return new Cached();
+	}
+
+	/**
+	 * Only meant to be used for a single thread
+	 */
+	public class Cached extends BiomeSource implements IESBiomeSource {
+
+		private final Long2ReferenceArrayMap<WorldArea> cachedAreas = new Long2ReferenceArrayMap<>(); // using array map because it usually only contain one element
+		private final Long2ReferenceFunction<WorldArea> getWorldAreaUncachedFunction = this::getWorldAreaUncached;
+
+		private WorldArea getWorldArea(int x, int z) {
+			int areaX = x >> 10;
+			int areaZ = z >> 10;
+			long areaPos = ChunkPos.asLong(areaX, areaZ);
+			return this.cachedAreas.computeIfAbsent(areaPos, getWorldAreaUncachedFunction);
+		}
+
+		private WorldArea getWorldAreaUncached(long pos) {
+			int x = ChunkPos.getX(pos);
+			int z = ChunkPos.getZ(pos);
+			return ESBiomeSource.this.provider.getWorldArea(x << 10, z << 10);
+		}
+
+		@Override
+		protected MapCodec<? extends BiomeSource> codec() {
+			return ESBiomeSource.this.codec();
+		}
+
+		@Override
+		protected Stream<Holder<Biome>> collectPossibleBiomes() {
+			return ESBiomeSource.this.collectPossibleBiomes();
+		}
+
+		@Override
+		public Holder<Biome> getNoiseBiome(int x, int y, int z, Climate.Sampler sampler) {
+			return provider.getBiomeDataById(getBiome(x * 4, z * 4)).biome();
+		}
+
+		@Override
+		public BiomeData getBiomeData(int x, int z) {
+			return this.getWorldArea(x, z).getBiomeData(x, z);
+		}
+
+		@Override
+		public int getBiome(int x, int z) {
+			return this.getWorldArea(x, z).getBiome(x, z);
+		}
+
+		@Override
+		public int getHeight(int x, int z) {
+			return this.getWorldArea(x, z).getHeight(x, z);
+		}
+
+	}
+
 }

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/world/gen/biomesource/IESBiomeSource.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/world/gen/biomesource/IESBiomeSource.java
@@ -1,0 +1,13 @@
+package cn.leolezury.eternalstarlight.common.world.gen.biomesource;
+
+import cn.leolezury.eternalstarlight.common.world.gen.system.BiomeData;
+
+public interface IESBiomeSource {
+
+	BiomeData getBiomeData(int x, int z);
+
+	int getBiome(int x, int z);
+
+	int getHeight(int x, int z);
+
+}

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/world/gen/chunkgenerator/IRandomState.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/world/gen/chunkgenerator/IRandomState.java
@@ -1,0 +1,12 @@
+package cn.leolezury.eternalstarlight.common.world.gen.chunkgenerator;
+
+import net.minecraft.world.level.levelgen.RandomState;
+import net.minecraft.world.level.levelgen.SurfaceSystem;
+
+public interface IRandomState extends Cloneable {
+
+	void setSurfaceSystem(SurfaceSystem surfaceSystem);
+
+	RandomState clone();
+
+}

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/world/gen/chunkgenerator/StarlightSurfaceSystem.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/world/gen/chunkgenerator/StarlightSurfaceSystem.java
@@ -1,7 +1,16 @@
 package cn.leolezury.eternalstarlight.common.world.gen.chunkgenerator;
 
-public interface StarlightSurfaceSystem {
+import cn.leolezury.eternalstarlight.common.world.gen.biomesource.IESBiomeSource;
+import net.minecraft.world.level.levelgen.SurfaceSystem;
+
+public interface StarlightSurfaceSystem extends Cloneable {
 	void setStarlightChunkGenerator(ESChunkGenerator generator);
 
+	void setCachedStarlightBiomeSource(IESBiomeSource biomeSource);
+
 	ESChunkGenerator getStarlightChunkGenerator();
+
+	IESBiomeSource getCachedStarlightBiomeSource();
+
+	SurfaceSystem clone();
 }

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/world/gen/surface/OnSurfaceCondition.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/world/gen/surface/OnSurfaceCondition.java
@@ -17,7 +17,11 @@ public class OnSurfaceCondition implements SurfaceRules.ConditionSource {
 	@Override
 	public SurfaceRules.Condition apply(SurfaceRules.Context context) {
 		if (context.system instanceof StarlightSurfaceSystem system && system.getStarlightChunkGenerator() != null) {
-			return () -> context.blockY >= system.getStarlightChunkGenerator().getSurfaceHeight(context.blockX, context.blockZ) - 8;
+			if (system.getCachedStarlightBiomeSource() != null) {
+				return () -> context.blockY >= system.getStarlightChunkGenerator().getSurfaceHeight(system.getCachedStarlightBiomeSource(), context.blockX, context.blockZ) - 8;
+			} else {
+				return () -> context.blockY >= system.getStarlightChunkGenerator().getSurfaceHeight(context.blockX, context.blockZ) - 8;
+			}
 		}
 		return () -> false;
 	}

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/world/gen/system/WorldGenProvider.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/world/gen/system/WorldGenProvider.java
@@ -87,7 +87,7 @@ public class WorldGenProvider {
 		int areaZ = z >> 10;
 		long areaPos = posAsLong(areaX, areaZ);
 		synchronized (generatedAreas) {
-			WorldArea area = generatedAreas.get(areaPos);
+			WorldArea area = generatedAreas.getAndMoveToFirst(areaPos);
 			if (area != null) {
 				return area;
 			} else {
@@ -101,9 +101,9 @@ public class WorldGenProvider {
 					area.transformHeights(transformer.transformer().value(), transformer.seedAddition);
 				}
 				area.finalizeAll(dataTransformerRegistry);
-				generatedAreas.put(areaPos, area);
+				generatedAreas.putAndMoveToFirst(areaPos, area);
 				while (generatedAreas.size() > cacheSize) {
-					generatedAreas.removeFirst();
+					generatedAreas.removeLast();
 				}
 			}
 			return area;

--- a/common/src/main/resources/eternal_starlight-common.mixins.json
+++ b/common/src/main/resources/eternal_starlight-common.mixins.json
@@ -21,6 +21,7 @@
     "PlayerMixin",
     "ProjectileMixin",
     "ProjectileWeaponItemMixin",
+    "RandomStateMixin",
     "ServerLevelMixin",
     "ServerPlayerMixin",
     "SignBlockMixin",

--- a/common/src/main/resources/eternal_starlight.accesswidener
+++ b/common/src/main/resources/eternal_starlight.accesswidener
@@ -93,6 +93,8 @@ accessible method net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer
 # chunkgen
 extendable class net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator
 accessible field net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator globalFluidPicker Ljava/util/function/Supplier;
+extendable method net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator doFill (Lnet/minecraft/world/level/levelgen/blending/Blender;Lnet/minecraft/world/level/StructureManager;Lnet/minecraft/world/level/levelgen/RandomState;Lnet/minecraft/world/level/chunk/ChunkAccess;II)Lnet/minecraft/world/level/chunk/ChunkAccess;
+extendable method net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator doCreateBiomes (Lnet/minecraft/world/level/levelgen/blending/Blender;Lnet/minecraft/world/level/levelgen/RandomState;Lnet/minecraft/world/level/StructureManager;Lnet/minecraft/world/level/chunk/ChunkAccess;)V
 
 # sweep attack for scythes and hammers
 accessible method net/minecraft/world/entity/player/Player getEnchantedDamage (Lnet/minecraft/world/entity/Entity;FLnet/minecraft/world/damagesource/DamageSource;)F


### PR DESCRIPTION
Accessing ESBiomeSource seem to be a very large performance bottleneck, and this PR addresses the issue by adding a local cache. 

Comparison in highly parallelized environment:  
Before: https://spark.lucko.me/gbIXSG6sS1?hl=13303,9737,9955 ([gbIXSG6sS1.sparkprofile.gz](https://github.com/user-attachments/files/18306955/gbIXSG6sS1.sparkprofile.gz))
After: https://spark.lucko.me/Gq6PnbzAEb?hl=132429,134138 ([Gq6PnbzAEb.sparkprofile.gz](https://github.com/user-attachments/files/18306959/Gq6PnbzAEb.sparkprofile.gz))

Comparison in normal environment with chunky, 1000 blocks radius:
Before: `[Chunky] Task finished for eternal_starlight:starlight. Processed: 16641 chunks (100.00%), Total time: 0:33:05`
After: `[Chunky] Task finished for eternal_starlight:starlight. Processed: 16641 chunks (100.00%), Total time: 0:12:08`

This PR also improves the caching behavior to only discard stale entries, and some other minor changes. 