### PR TITLE
Add Flan Compatibility and update RayAttack

### DIFF
--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/client/helper/ClientHelper.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/client/helper/ClientHelper.java
@@ -1,7 +1,11 @@
 package cn.leolezury.eternalstarlight.common.client.helper;
 
+import javax.annotation.Nullable;
+
 import cn.leolezury.eternalstarlight.common.network.*;
 import cn.leolezury.eternalstarlight.common.spell.ManaType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.phys.Vec3;
 
 public interface ClientHelper {
@@ -26,4 +30,7 @@ public interface ClientHelper {
 	void spawnStellarRackItemParticles(Vec3 center);
 
 	void spawnManaCrystalItemParticles(ManaType type, Vec3 center);
+	
+	@Nullable
+	GameType getLocalGameMode(Player maybeLocalPlayer);
 }

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/client/helper/ClientSideHelper.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/client/helper/ClientSideHelper.java
@@ -28,17 +28,22 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Quaternionf;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import javax.annotation.Nullable;
 
 @Environment(EnvType.CLIENT)
 public class ClientSideHelper implements ClientHelper {
@@ -406,6 +411,16 @@ public class ClientSideHelper implements ClientHelper {
 					SmoothSegmentedValue.of(Easing.OUT_QUINT, 0, 1f, 0.7f).add(Easing.IN_OUT_QUAD, 1f, 0, 0.3f))
 				.defaultOperators()
 				.spawn(BuiltInRegistries.PARTICLE_TYPE.getKey(ESParticles.ADVANCED_GLOW.get()), (float) pos.x, (float) pos.y, (float) pos.z);
+		}
+	}
+
+	@Override
+	@Nullable
+	public GameType getLocalGameMode(Player maybeLocalPlayer) {
+		if(maybeLocalPlayer instanceof LocalPlayer || maybeLocalPlayer == Minecraft.getInstance().player) {
+			return Minecraft.getInstance().gameMode.getPlayerMode();
+		} else {
+			return null;
 		}
 	}
 }

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/client/helper/EmptyClientHelper.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/client/helper/EmptyClientHelper.java
@@ -1,7 +1,11 @@
 package cn.leolezury.eternalstarlight.common.client.helper;
 
+import javax.annotation.Nullable;
+
 import cn.leolezury.eternalstarlight.common.network.*;
 import cn.leolezury.eternalstarlight.common.spell.ManaType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.phys.Vec3;
 
 public class EmptyClientHelper implements ClientHelper {
@@ -58,5 +62,11 @@ public class EmptyClientHelper implements ClientHelper {
 	@Override
 	public void spawnManaCrystalItemParticles(ManaType type, Vec3 center) {
 
+	}
+	
+	@Override
+	@Nullable
+	public GameType getLocalGameMode(Player maybeLocalPlayer) {
+		return null;
 	}
 }

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/compatibility/ESFlanCompatibility.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/compatibility/ESFlanCompatibility.java
@@ -1,0 +1,61 @@
+package cn.leolezury.eternalstarlight.common.compatibility;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+import cn.leolezury.eternalstarlight.common.EternalStarlight;
+import cn.leolezury.eternalstarlight.common.compatibility.empty.EmptyFlanCompatibility;
+import cn.leolezury.eternalstarlight.common.config.ESConfig;
+import net.minecraft.Util;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+
+public interface ESFlanCompatibility extends ESModCompatibility {
+	ESFlanCompatibility INSTANCE = Util.make(() -> {
+		final ServiceLoader<ESFlanCompatibility> loader = ServiceLoader.load(ESFlanCompatibility.class);
+		final Iterator<ESFlanCompatibility> iterator = loader.iterator();
+		if (!iterator.hasNext()) {
+			// Optional compatibility preferably shouldn't cause the mod to error or fail loading
+			EternalStarlight.LOGGER.warn("Flan compatibility instance not found! Defaulting to empty...");
+			return new EmptyFlanCompatibility();
+		} else {
+			ESFlanCompatibility instance = iterator.next();
+			if (iterator.hasNext()) {
+				EternalStarlight.LOGGER.warn("More than one Flan compatibility instance was found! Defaulting to empty...");
+				return new EmptyFlanCompatibility();
+			}
+			return instance;
+		}
+	});
+	
+	String MOD_ID = "flan";
+	
+	// Instance methods
+	@Override
+	default String getModId() {
+		return MOD_ID;
+	}
+	
+	public boolean claimRestrictsBlockBreak(ServerLevel level, BlockPos pos, Entity entity);
+
+	public boolean claimRestrictsBlockPlace(ServerLevel level, BlockPos pos, Entity entity);
+	
+	// Static methods
+	public static boolean restrictBlockBreak(Level level, BlockPos pos, Entity entity) {
+		if(ESConfig.INSTANCE.checkFlanClaims && level instanceof ServerLevel serverLevel) {
+			return ESFlanCompatibility.INSTANCE.isModLoaded() && ESFlanCompatibility.INSTANCE.claimRestrictsBlockBreak(serverLevel, pos, entity);
+		} else {
+			return false;
+		}
+	}
+
+	public static boolean restrictBlockPlace(ServerLevel level, BlockPos pos, Entity entity) {
+		if(ESConfig.INSTANCE.checkFlanClaims && level instanceof ServerLevel serverLevel) {
+			return ESFlanCompatibility.INSTANCE.isModLoaded() && ESFlanCompatibility.INSTANCE.claimRestrictsBlockPlace(serverLevel, pos, entity);
+		} else {
+			return false;
+		}
+	}
+}

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/compatibility/ESFlanCompatibility.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/compatibility/ESFlanCompatibility.java
@@ -51,7 +51,7 @@ public interface ESFlanCompatibility extends ESModCompatibility {
 		}
 	}
 
-	public static boolean restrictBlockPlace(ServerLevel level, BlockPos pos, Entity entity) {
+	public static boolean restrictBlockPlace(Level level, BlockPos pos, Entity entity) {
 		if(ESConfig.INSTANCE.checkFlanClaims && level instanceof ServerLevel serverLevel) {
 			return ESFlanCompatibility.INSTANCE.isModLoaded() && ESFlanCompatibility.INSTANCE.claimRestrictsBlockPlace(serverLevel, pos, entity);
 		} else {

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/compatibility/ESModCompatibility.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/compatibility/ESModCompatibility.java
@@ -3,15 +3,10 @@ package cn.leolezury.eternalstarlight.common.compatibility;
 import java.util.Optional;
 
 import cn.leolezury.eternalstarlight.common.platform.ESPlatform;
-import net.minecraft.resources.ResourceLocation;
 
 public interface ESModCompatibility {
 
 	public String getModId();
-	
-	public default ResourceLocation location(String path) {
-		return ResourceLocation.fromNamespaceAndPath(this.getModId(), path);
-	}
 	
 	public boolean isModLoaded();
 	

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/compatibility/ESModCompatibility.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/compatibility/ESModCompatibility.java
@@ -1,0 +1,22 @@
+package cn.leolezury.eternalstarlight.common.compatibility;
+
+import java.util.Optional;
+
+import cn.leolezury.eternalstarlight.common.platform.ESPlatform;
+import net.minecraft.resources.ResourceLocation;
+
+public interface ESModCompatibility {
+
+	public String getModId();
+	
+	public default ResourceLocation location(String path) {
+		return ResourceLocation.fromNamespaceAndPath(this.getModId(), path);
+	}
+	
+	public boolean isModLoaded();
+	
+	public Optional<String> getModVersion();
+	
+	public Optional<ESPlatform.Loader> getLoader();
+	
+}

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/compatibility/empty/EmptyFlanCompatibility.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/compatibility/empty/EmptyFlanCompatibility.java
@@ -1,0 +1,38 @@
+package cn.leolezury.eternalstarlight.common.compatibility.empty;
+
+import java.util.Optional;
+
+import cn.leolezury.eternalstarlight.common.compatibility.ESFlanCompatibility;
+import cn.leolezury.eternalstarlight.common.platform.ESPlatform.Loader;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+
+public class EmptyFlanCompatibility implements ESFlanCompatibility {
+
+	@Override
+	public boolean isModLoaded() {
+		return false;
+	}
+	
+	@Override
+	public Optional<String> getModVersion() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<Loader> getLoader() {
+		return Optional.empty();
+	}
+
+	@Override
+	public boolean claimRestrictsBlockBreak(ServerLevel level, BlockPos pos, Entity entity) {
+		return false;
+	}
+
+	@Override
+	public boolean claimRestrictsBlockPlace(ServerLevel level, BlockPos pos, Entity entity) {
+		return false;
+	}
+
+}

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/config/ESConfig.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/config/ESConfig.java
@@ -22,6 +22,7 @@ public class ESConfig {
 	public boolean enableScreenShake = true;
 	public int crystalbornCatalystEnergyPerShard = 50;
 	public boolean laserBeamBreakBlocks = true;
+	public boolean checkFlanClaims = true;
 	public MobsConfig mobsConfig = new MobsConfig();
 
 	public static class MobsConfig {

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/entity/attack/ray/RayAttack.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/entity/attack/ray/RayAttack.java
@@ -1,5 +1,7 @@
 package cn.leolezury.eternalstarlight.common.entity.attack.ray;
 
+import java.util.Optional;
+
 import cn.leolezury.eternalstarlight.common.config.ESConfig;
 import cn.leolezury.eternalstarlight.common.data.ESDamageTypes;
 import cn.leolezury.eternalstarlight.common.entity.interfaces.RayAttackUser;
@@ -13,7 +15,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -24,8 +25,6 @@ import net.minecraft.world.level.material.PushReaction;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.CollisionContext;
-
-import java.util.Optional;
 
 public class RayAttack extends Entity {
 	protected static final EntityDataAccessor<Integer> CASTER = SynchedEntityData.defineId(RayAttack.class, EntityDataSerializers.INT);
@@ -128,17 +127,14 @@ public class RayAttack extends Entity {
 	public int getRadius() {
 		return 20;
 	}
-
+	
 	public void onFirstHit(ESEntityUtil.RaytraceResult result) {
 		getCaster().ifPresent(caster -> {
 			if (result.blockHitResult() != null) {
 				BlockPos hitPos = result.blockHitResult().getBlockPos();
 				destroyProgresses.put(hitPos, destroyProgresses.containsKey(hitPos) ? destroyProgresses.getInt(hitPos) + 1 : 1);
 				if (destroyProgresses.getInt(hitPos) > 60) {
-					boolean canDestroy = ESPlatform.INSTANCE.postMobGriefingEvent(this.level(), caster) && ESConfig.INSTANCE.laserBeamBreakBlocks;
-					if (caster instanceof ServerPlayer player && (!level().mayInteract(player, hitPos) || player.blockActionRestricted(level(), hitPos, player.gameMode.getGameModeForPlayer()))) {
-						canDestroy = false;
-					}
+					boolean canDestroy = ESConfig.INSTANCE.laserBeamBreakBlocks && ESPlatform.INSTANCE.postEntityDestroyBlockEvent(level(), caster, hitPos);
 					if (canDestroy) {
 						BlockState blockState = level().getBlockState(hitPos);
 						if (blockState.getDestroySpeed(level(), hitPos) >= 0) {

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/platform/ESPlatform.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/platform/ESPlatform.java
@@ -1,8 +1,10 @@
 package cn.leolezury.eternalstarlight.common.platform;
 
+import cn.leolezury.eternalstarlight.common.EternalStarlight;
 import cn.leolezury.eternalstarlight.common.block.fluid.EtherFluid;
 import cn.leolezury.eternalstarlight.common.client.ESDimensionSpecialEffects;
 import cn.leolezury.eternalstarlight.common.client.model.item.GlowingBakedModel;
+import cn.leolezury.eternalstarlight.common.compatibility.ESFlanCompatibility;
 import cn.leolezury.eternalstarlight.common.item.armor.AlchemistArmorItem;
 import cn.leolezury.eternalstarlight.common.item.armor.ThermalSpringstoneArmorItem;
 import cn.leolezury.eternalstarlight.common.item.weapon.CrescentSpearItem;
@@ -35,11 +37,14 @@ import net.minecraft.tags.ItemTags;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.Boat;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.GameRules;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.FlowerPotBlock;
@@ -53,6 +58,8 @@ import java.util.ServiceLoader;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
 
 public interface ESPlatform {
 	ESPlatform INSTANCE = Util.make(() -> {
@@ -124,6 +131,18 @@ public interface ESPlatform {
 	default EtherFluid.Flowing createFlowingEtherFluid() {
 		return new EtherFluid.Flowing();
 	}
+	
+	// player info
+	@Nullable
+	default GameType getGameType(Player player) {
+		if(player instanceof ServerPlayer serverPlayer) {
+			return serverPlayer.gameMode.getGameModeForPlayer();
+		} else if(this.isPhysicalClient()) {
+			return EternalStarlight.getClientHelper().getLocalGameMode(player);
+		} else {
+			return null;
+		}
+	}
 
 	// reload listeners
 	default TheGatekeeperNameManager createGatekeeperNameManager() {
@@ -136,6 +155,31 @@ public interface ESPlatform {
 	}
 
 	default boolean postTravelToDimensionEvent(Entity entity, ResourceKey<Level> dimension) {
+		return true;
+	}
+	
+	default boolean postEntityDestroyBlockEvent(Level level, Entity entity, BlockPos pos) {
+		// Flan compatibility
+		if(ESFlanCompatibility.restrictBlockBreak(level, pos, entity)) {
+			return false;
+		}
+		
+		// Players typically should not be subjected to mobGriefing
+		if(!(entity instanceof Player player)) {
+			return this.postMobGriefingEvent(level, entity);
+		}
+		
+		// Worldborder & Spawn Protection mainly
+		if(!level.mayInteract(player, pos)) {
+			return false;
+		}
+		
+		// Game type support for the client as well
+		GameType gameType = this.getGameType(player);
+		if(gameType != null && player.blockActionRestricted(level, pos, gameType)) {
+			return false;
+		}
+		
 		return true;
 	}
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -21,11 +21,14 @@ configurations {
 
 repositories {
     maven { url = "https://jitpack.io" } // Fabric ASM
+    maven { url = "https://gitlab.com/api/v4/projects/21830712/packages/maven" } // Flan
 }
 
 dependencies {
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
     modApi "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}"
+
+	modCompileOnly("io.github.flemmli97:flan:${rootProject.minecraft_version}-${rootProject.flan_version}-fabric:api") { transitive false }
 
     // modImplementation "com.github.Chocohead:Fabric-ASM:${rootProject.fabric_asm_version}"
     // include "com.github.Chocohead:Fabric-ASM:${rootProject.fabric_asm_version}"

--- a/fabric/src/main/java/cn/leolezury/eternalstarlight/fabric/compatibility/fabric/FabricFlanCompatibility.java
+++ b/fabric/src/main/java/cn/leolezury/eternalstarlight/fabric/compatibility/fabric/FabricFlanCompatibility.java
@@ -1,0 +1,25 @@
+package cn.leolezury.eternalstarlight.fabric.compatibility.fabric;
+
+import com.google.auto.service.AutoService;
+
+import cn.leolezury.eternalstarlight.common.compatibility.ESFlanCompatibility;
+import io.github.flemmli97.flan.api.ClaimHandler;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+
+@AutoService(ESFlanCompatibility.class)
+public class FabricFlanCompatibility implements ESFlanCompatibility, FabricModCompatibility {
+
+	@Override
+	public boolean claimRestrictsBlockBreak(ServerLevel level, BlockPos pos, Entity entity) {
+		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, this.location("break"));
+	}
+
+	@Override
+	public boolean claimRestrictsBlockPlace(ServerLevel level, BlockPos pos, Entity entity) {
+		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, this.location("place"));
+	}
+
+}

--- a/fabric/src/main/java/cn/leolezury/eternalstarlight/fabric/compatibility/fabric/FabricFlanCompatibility.java
+++ b/fabric/src/main/java/cn/leolezury/eternalstarlight/fabric/compatibility/fabric/FabricFlanCompatibility.java
@@ -4,6 +4,7 @@ import com.google.auto.service.AutoService;
 
 import cn.leolezury.eternalstarlight.common.compatibility.ESFlanCompatibility;
 import io.github.flemmli97.flan.api.ClaimHandler;
+import io.github.flemmli97.flan.api.permission.BuiltinPermission;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -14,12 +15,12 @@ public class FabricFlanCompatibility implements ESFlanCompatibility, FabricModCo
 
 	@Override
 	public boolean claimRestrictsBlockBreak(ServerLevel level, BlockPos pos, Entity entity) {
-		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, this.location("break"));
+		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, BuiltinPermission.BREAK);
 	}
 
 	@Override
 	public boolean claimRestrictsBlockPlace(ServerLevel level, BlockPos pos, Entity entity) {
-		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, this.location("place"));
+		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, BuiltinPermission.PLACE);
 	}
 
 }

--- a/fabric/src/main/java/cn/leolezury/eternalstarlight/fabric/compatibility/fabric/FabricFlanCompatibility.java
+++ b/fabric/src/main/java/cn/leolezury/eternalstarlight/fabric/compatibility/fabric/FabricFlanCompatibility.java
@@ -6,6 +6,7 @@ import cn.leolezury.eternalstarlight.common.compatibility.ESFlanCompatibility;
 import io.github.flemmli97.flan.api.ClaimHandler;
 import io.github.flemmli97.flan.api.permission.BuiltinPermission;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
@@ -13,14 +14,18 @@ import net.minecraft.world.entity.Entity;
 @AutoService(ESFlanCompatibility.class)
 public class FabricFlanCompatibility implements ESFlanCompatibility, FabricModCompatibility {
 
+	public static boolean canInteract(ServerLevel level, Entity entity, BlockPos pos, ResourceLocation permission) {
+		return ClaimHandler.getPermissionStorage(level).getForPermissionCheck(pos).canInteract(entity instanceof ServerPlayer player ? player : null, permission, pos);
+	}
+	
 	@Override
 	public boolean claimRestrictsBlockBreak(ServerLevel level, BlockPos pos, Entity entity) {
-		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, BuiltinPermission.BREAK);
+		return !canInteract(level, entity, pos, BuiltinPermission.BREAK);
 	}
 
 	@Override
 	public boolean claimRestrictsBlockPlace(ServerLevel level, BlockPos pos, Entity entity) {
-		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, BuiltinPermission.PLACE);
+		return !canInteract(level, entity, pos, BuiltinPermission.PLACE);
 	}
 
 }

--- a/fabric/src/main/java/cn/leolezury/eternalstarlight/fabric/compatibility/fabric/FabricModCompatibility.java
+++ b/fabric/src/main/java/cn/leolezury/eternalstarlight/fabric/compatibility/fabric/FabricModCompatibility.java
@@ -1,0 +1,49 @@
+package cn.leolezury.eternalstarlight.fabric.compatibility.fabric;
+
+import java.util.Optional;
+
+import cn.leolezury.eternalstarlight.common.compatibility.ESModCompatibility;
+import cn.leolezury.eternalstarlight.common.platform.ESPlatform.Loader;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.SemanticVersion;
+import net.fabricmc.loader.api.Version;
+
+public interface FabricModCompatibility extends ESModCompatibility {
+
+	@Override
+	public default boolean isModLoaded() {
+		return FabricLoader.getInstance().isModLoaded(this.getModId());
+	}
+
+	@Override
+	public default Optional<String> getModVersion() {
+		if(!isModLoaded()) {
+			return Optional.empty();
+		} else {
+			return FabricLoader.getInstance()
+					.getModContainer(this.getModId())
+					.map(container -> {
+						Version version = container.getMetadata().getVersion();
+						// Strip to just the components if possible
+						if(version instanceof SemanticVersion semanticVersion) {
+							final int componentCount = semanticVersion.getVersionComponentCount();
+							StringBuilder componentOnlyBuilder = new StringBuilder(componentCount * 2 - 1);
+							for(int i = 0; i < componentCount - 1; ++i) {
+								componentOnlyBuilder.append(semanticVersion.getVersionComponent(i));
+								componentOnlyBuilder.append('.');
+							}
+							componentOnlyBuilder.append(semanticVersion.getVersionComponent(componentCount - 1));
+							return componentOnlyBuilder.toString();
+						} else {
+							return version.getFriendlyString();
+						}
+					}
+				);
+		}
+	}
+
+	@Override
+	public default Optional<Loader> getLoader() {
+		return Optional.of(Loader.FABRIC);
+	}
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,4 @@ maven_group=cn.leolezury
 fabric_loader_version=0.16.10
 fabric_api_version=0.115.1+1.21.1
 neoforge_version=21.1.133
+flan_version=1.10.10

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -30,12 +30,14 @@ configurations {
 
 repositories {
     maven { url "https://maven.neoforged.net/releases/" }
+    maven { url = "https://gitlab.com/api/v4/projects/21830712/packages/maven" } // Flan
 }
 
 dependencies {
     neoForge "net.neoforged:neoforge:${rootProject.neoforge_version}"
     // Remove the next line if you don't want to depend on the API
     // modApi "dev.architectury:architectury-forge:${rootProject.architectury_version}"
+	compileOnly("io.github.flemmli97:flan:${rootProject.minecraft_version}-${rootProject.flan_version}-neoforge:api")
 
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionNeoForge")) { transitive false }

--- a/neoforge/src/main/java/cn/leolezury/eternalstarlight/neoforge/compatibility/neoforge/NeoForgeFlanCompatibility.java
+++ b/neoforge/src/main/java/cn/leolezury/eternalstarlight/neoforge/compatibility/neoforge/NeoForgeFlanCompatibility.java
@@ -1,0 +1,25 @@
+package cn.leolezury.eternalstarlight.neoforge.compatibility.neoforge;
+
+import com.google.auto.service.AutoService;
+
+import cn.leolezury.eternalstarlight.common.compatibility.ESFlanCompatibility;
+import io.github.flemmli97.flan.api.ClaimHandler;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+
+@AutoService(ESFlanCompatibility.class)
+public class NeoForgeFlanCompatibility implements ESFlanCompatibility, NeoForgeModCompatibility {
+
+	@Override
+	public boolean claimRestrictsBlockBreak(ServerLevel level, BlockPos pos, Entity entity) {
+		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, this.location("break"));
+	}
+
+	@Override
+	public boolean claimRestrictsBlockPlace(ServerLevel level, BlockPos pos, Entity entity) {
+		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, this.location("place"));
+	}
+
+}

--- a/neoforge/src/main/java/cn/leolezury/eternalstarlight/neoforge/compatibility/neoforge/NeoForgeFlanCompatibility.java
+++ b/neoforge/src/main/java/cn/leolezury/eternalstarlight/neoforge/compatibility/neoforge/NeoForgeFlanCompatibility.java
@@ -6,6 +6,7 @@ import cn.leolezury.eternalstarlight.common.compatibility.ESFlanCompatibility;
 import io.github.flemmli97.flan.api.ClaimHandler;
 import io.github.flemmli97.flan.api.permission.BuiltinPermission;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
@@ -13,14 +14,18 @@ import net.minecraft.world.entity.Entity;
 @AutoService(ESFlanCompatibility.class)
 public class NeoForgeFlanCompatibility implements ESFlanCompatibility, NeoForgeModCompatibility {
 
+	public static boolean canInteract(ServerLevel level, Entity entity, BlockPos pos, ResourceLocation permission) {
+		return ClaimHandler.getPermissionStorage(level).getForPermissionCheck(pos).canInteract(entity instanceof ServerPlayer player ? player : null, permission, pos);
+	}
+	
 	@Override
 	public boolean claimRestrictsBlockBreak(ServerLevel level, BlockPos pos, Entity entity) {
-		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, BuiltinPermission.BREAK);
+		return !canInteract(level, entity, pos, BuiltinPermission.BREAK);
 	}
 
 	@Override
 	public boolean claimRestrictsBlockPlace(ServerLevel level, BlockPos pos, Entity entity) {
-		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, BuiltinPermission.PLACE);
+		return !canInteract(level, entity, pos, BuiltinPermission.PLACE);
 	}
 
 }

--- a/neoforge/src/main/java/cn/leolezury/eternalstarlight/neoforge/compatibility/neoforge/NeoForgeFlanCompatibility.java
+++ b/neoforge/src/main/java/cn/leolezury/eternalstarlight/neoforge/compatibility/neoforge/NeoForgeFlanCompatibility.java
@@ -4,6 +4,7 @@ import com.google.auto.service.AutoService;
 
 import cn.leolezury.eternalstarlight.common.compatibility.ESFlanCompatibility;
 import io.github.flemmli97.flan.api.ClaimHandler;
+import io.github.flemmli97.flan.api.permission.BuiltinPermission;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -14,12 +15,12 @@ public class NeoForgeFlanCompatibility implements ESFlanCompatibility, NeoForgeM
 
 	@Override
 	public boolean claimRestrictsBlockBreak(ServerLevel level, BlockPos pos, Entity entity) {
-		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, this.location("break"));
+		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, BuiltinPermission.BREAK);
 	}
 
 	@Override
 	public boolean claimRestrictsBlockPlace(ServerLevel level, BlockPos pos, Entity entity) {
-		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, this.location("place"));
+		return !ClaimHandler.canInteract(entity instanceof ServerPlayer player ? player : null, pos, BuiltinPermission.PLACE);
 	}
 
 }

--- a/neoforge/src/main/java/cn/leolezury/eternalstarlight/neoforge/compatibility/neoforge/NeoForgeModCompatibility.java
+++ b/neoforge/src/main/java/cn/leolezury/eternalstarlight/neoforge/compatibility/neoforge/NeoForgeModCompatibility.java
@@ -1,0 +1,70 @@
+package cn.leolezury.eternalstarlight.neoforge.compatibility.neoforge;
+
+import java.util.Optional;
+import java.util.StringTokenizer;
+
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+
+import cn.leolezury.eternalstarlight.common.compatibility.ESModCompatibility;
+import cn.leolezury.eternalstarlight.common.platform.ESPlatform.Loader;
+import net.neoforged.fml.ModList;
+
+public interface NeoForgeModCompatibility extends ESModCompatibility {
+
+	@Override
+	public default boolean isModLoaded() {
+		return ModList.get().isLoaded(this.getModId());
+	}
+
+	@Override
+	public default Optional<String> getModVersion() {
+		if(!isModLoaded()) {
+			return Optional.empty();
+		} else {
+			return ModList.get()
+					.getModContainerById(this.getModId())
+					.map(container -> {
+						ArtifactVersion artifactVersion = container.getModInfo().getVersion();
+						// Strip to just the components if possible
+						final String qualifier = artifactVersion.getQualifier();
+						final int buildDelimPos = qualifier.indexOf('+');
+						final int dashDelimPos = qualifier.indexOf('-');
+						if(buildDelimPos < 0 && dashDelimPos <= 0) {
+							return qualifier;
+						} else {
+							int index = qualifier.length();
+							if(buildDelimPos != -1) {
+								index = buildDelimPos;
+							}
+							if(dashDelimPos != -1 && dashDelimPos < index) {
+								index = dashDelimPos;
+							}
+							String version = qualifier.substring(0, index);
+							StringTokenizer tokenizer = new StringTokenizer(version, ".");
+							StringBuilder builder = new StringBuilder();
+							boolean prev = false;
+							while(tokenizer.hasMoreTokens()) {
+								String token = tokenizer.nextToken();
+								if(NumberUtils.isDigits(token)) {
+									if(prev) {
+										builder.append('.');
+									}
+									builder.append(token);
+									prev = true;
+								} else {
+									break;
+								}
+							}
+							return builder.toString();
+						}
+					}
+				);
+		}
+	}
+
+	@Override
+	public default Optional<Loader> getLoader() {
+		return Optional.of(Loader.NEOFORGE);
+	}
+}

--- a/neoforge/src/main/java/cn/leolezury/eternalstarlight/neoforge/platform/NeoForgePlatform.java
+++ b/neoforge/src/main/java/cn/leolezury/eternalstarlight/neoforge/platform/NeoForgePlatform.java
@@ -41,7 +41,9 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.Boat;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.context.UseOnContext;
@@ -237,6 +239,15 @@ public class NeoForgePlatform implements ESPlatform {
 	@Override
 	public boolean postTravelToDimensionEvent(Entity entity, ResourceKey<Level> dimension) {
 		return CommonHooks.onTravelToDimension(entity, dimension);
+	}
+	
+	@Override
+	public boolean postEntityDestroyBlockEvent(Level level, Entity entity, BlockPos pos) {
+		// Check forge hooks as well
+		if(entity instanceof LivingEntity livingEntity && !(entity instanceof Player) && !CommonHooks.canEntityDestroy(level, pos, livingEntity)) {
+			return false;
+		}
+		return ESPlatform.super.postEntityDestroyBlockEvent(level, entity, pos);
 	}
 
 	@Override


### PR DESCRIPTION
Intended as a resolution for my issue #59:
* Centralizes some of the code for checking whether or not a block can be broken by an entity.
* Adds compatibility for the "Flan" mod's claims.
* Adds a `"checkFlanClaims"` config option to enable/disable Flan compatibility (default `true`).
* Updates `RayAttack` to check the new centralized checks.