### PR TITLE
Improve efficiency of modifying models

### DIFF
--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/client/handler/ClientSetupHandlers.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/client/handler/ClientSetupHandlers.java
@@ -618,12 +618,10 @@ public class ClientSetupHandlers {
 
 	public static void modifyBakingResult(Map<ModelResourceLocation, BakedModel> models) {
 		if (!modifiedBakedModels) {
-			BAKED_MODELS.clear();
 			for (ModelResourceLocation id : models.keySet()) {
-				if (id.id().toString().contains(EternalStarlight.ID + ":thermal_springstone_")) {
+				if (id.id().getNamespace().equals(EternalStarlight.ID) && id.id().getPath().startsWith("thermal_springstone_")) {
 					models.put(id, ESPlatform.INSTANCE.getGlowingBakedModel(models.get(id)));
 				}
-				BAKED_MODELS.put(id, models.get(id));
 			}
 			modifiedBakedModels = true;
 		}

--- a/common/src/main/java/cn/leolezury/eternalstarlight/common/mixin/client/ItemRendererMixin.java
+++ b/common/src/main/java/cn/leolezury/eternalstarlight/common/mixin/client/ItemRendererMixin.java
@@ -22,8 +22,8 @@ public abstract class ItemRendererMixin {
 	public BakedModel render(BakedModel bakedModel, ItemStack stack, ItemDisplayContext itemDisplayContext) {
 		ResourceLocation itemKey = BuiltInRegistries.ITEM.getKey(stack.getItem());
 		if (ClientSetupHandlers.ITEMS_WITH_SPECIAL_MODEL.containsKey(new ModelResourceLocation(itemKey, "inventory")) && ClientSetupHandlers.ITEMS_WITH_SPECIAL_MODEL.get(new ModelResourceLocation(itemKey, "inventory")).containsKey(itemDisplayContext)) {
-			BakedModel replacedModel = ClientSetupHandlers.BAKED_MODELS.get(ClientSetupHandlers.getSpecialModel(new ModelResourceLocation(itemKey, "inventory"), itemDisplayContext));
-			if (replacedModel != null) {
+			BakedModel replacedModel = Minecraft.getInstance().getModelManager().getModel(ClientSetupHandlers.getSpecialModel(new ModelResourceLocation(itemKey, "inventory"), itemDisplayContext));
+			if (replacedModel != Minecraft.getInstance().getModelManager().getMissingModel()) {
 				return replacedModel.getOverrides().resolve(replacedModel, stack, Minecraft.getInstance().level, null, 0);
 			}
 		}


### PR DESCRIPTION
This PR fixes some inefficiencies in the model modification code:

* Converting the `ModelResourceLocation` id to a string first is unnecessary, the namespace and path checks can just be split. This greatly improves the efficiency of iterating through the list of locations as the namespace check can exit early most of the time, rather than having to convert the full location to a string whether it matches or not.
* The `BAKED_MODELS` map appears to be unnecessary and a waste of memory, as it's just a copy of the existing registry provided by the vanilla `ModelManager`. Moreover, querying every model (regardless of whether it belongs to Eternal Starlight and needs modification) breaks ModernFix's dynamic model loading optimization if enabled, as it forces every model to be loaded at startup which takes a long time. I've removed it and made the appropriate change in the mixin to use the model manager directly.